### PR TITLE
fix:  The lifetime of AbpCookieAuthenticationHandler 

### DIFF
--- a/aspnet-core/services/LY.AIO.Applications.Single/MicroServiceApplicationsSingleModule.Configure.cs
+++ b/aspnet-core/services/LY.AIO.Applications.Single/MicroServiceApplicationsSingleModule.Configure.cs
@@ -858,7 +858,10 @@ public partial class MicroServiceApplicationsSingleModule
             options.AutoValidate = false;
         });
 
-        services.Replace<CookieAuthenticationHandler, AbpCookieAuthenticationHandler>(ServiceLifetime.Scoped);
+        var originalDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(CookieAuthenticationHandler));
+        var originalLifetime = originalDescriptor?.Lifetime ?? ServiceLifetime.Transient; // 默认用 Transient
+
+        services.Replace<CookieAuthenticationHandler, AbpCookieAuthenticationHandler>(originalLifetime);
 
         services.AddAuthentication()
                 .AddAbpJwtBearer(options =>


### PR DESCRIPTION
The lifetime of AbpCookieAuthenticationHandler  needs to be configured as Transient, otherwise the extraction of the cookie named Identity.External will fail