### PR TITLE
fix(wechat): Fix null object references

### DIFF
--- a/aspnet-core/framework/wechat/LINGYUN.Abp.WeChat.Work/LINGYUN/Abp/WeChat/Work/Tags/Request/WeChatWorkTagChangeMemberRequest.cs
+++ b/aspnet-core/framework/wechat/LINGYUN.Abp.WeChat.Work/LINGYUN/Abp/WeChat/Work/Tags/Request/WeChatWorkTagChangeMemberRequest.cs
@@ -45,11 +45,11 @@ public class WeChatWorkTagChangeMemberRequest
         {
             throw new ArgumentNullException("users/parts", "userlist、partylist不能同时为空!");
         }
-        if (users.Count > 1000)
+        if (users?.Count > 1000)
         {
             throw new ArgumentOutOfRangeException(nameof(users), "企业成员ID列表单次请求个数不超过1000!");
         }
-        if (parts.Count > 100)
+        if (parts?.Count > 100)
         {
             throw new ArgumentOutOfRangeException(nameof(users), "企业部门ID列表单次请求个数不超过100!");
         }

--- a/aspnet-core/framework/wechat/LINGYUN.Abp.WeChat.Work/LINGYUN/Abp/WeChat/Work/Tags/Response/WeChatWorkTagCreateResponse.cs
+++ b/aspnet-core/framework/wechat/LINGYUN.Abp.WeChat.Work/LINGYUN/Abp/WeChat/Work/Tags/Response/WeChatWorkTagCreateResponse.cs
@@ -17,5 +17,5 @@ public class WeChatWorkTagCreateResponse : WeChatWorkResponse
     [NotNull]
     [JsonProperty("tagid")]
     [JsonPropertyName("tagid")]
-    public string TagId { get; set; }
+    public int TagId { get; set; }
 }


### PR DESCRIPTION
- Fix the tag member change parameter check for possible empty references
- The TagId parameter in the tag response parameter is of int type