### PR TITLE
fix(text-templating): failed to fix the change template

### DIFF
--- a/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/AbpTextTemplatingDomainModule.cs
+++ b/aspnet-core/modules/text-templating/LINGYUN.Abp.TextTemplating.Domain/LINGYUN/Abp/TextTemplating/AbpTextTemplatingDomainModule.cs
@@ -35,7 +35,8 @@ public class AbpTextTemplatingDomainModule : AbpModule
             options.EtoMappings.Add<TextTemplate, TextTemplateEto>();
             options.EtoMappings.Add<TextTemplateDefinition, TextTemplateDefinitionEto>();
 
-            options.AutoEventSelectors.Add<TextTemplate>();
+            // TODO: CAP组件异常将导致应用无法启动, 临时禁用
+            // options.AutoEventSelectors.Add<TextTemplate>();
         });
 
         if (context.Services.IsDataMigrationEnvironment())


### PR DESCRIPTION
- Display name localization serialization
- Ignore the exception for obtaining template content
- Remove the Eto registration of the text template to prevent the failure of event sending at startup