### PR TITLE
fix(vben5): update vxe toolbar refresh config

### DIFF
--- a/apps/vben5/packages/@abp/ai-management/src/components/tools/AIToolDefinitionTable.vue
+++ b/apps/vben5/packages/@abp/ai-management/src/components/tools/AIToolDefinitionTable.vue
@@ -140,7 +140,8 @@ const gridOptions: VxeGridProps<AIToolDefinitionRecordDto> = {
     custom: true,
     export: true,
     // import: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/ai-management/src/components/workspaces/WorkspaceDefinitionTable.vue
+++ b/apps/vben5/packages/@abp/ai-management/src/components/workspaces/WorkspaceDefinitionTable.vue
@@ -130,7 +130,8 @@ const gridOptions: VxeGridProps<WorkspaceDefinitionRecordDto> = {
     custom: true,
     export: true,
     // import: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/auditing/src/components/audit-logs/AuditLogTable.vue
+++ b/apps/vben5/packages/@abp/auditing/src/components/audit-logs/AuditLogTable.vue
@@ -241,7 +241,8 @@ const gridOptions: VxeGridProps<AuditLogDto> = {
     custom: true,
     export: true,
     // import: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/auditing/src/components/loggings/LoggingTable.vue
+++ b/apps/vben5/packages/@abp/auditing/src/components/loggings/LoggingTable.vue
@@ -278,7 +278,8 @@ const gridOptions: VxeGridProps<LogDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/blob-management/src/components/containers/BlobContainerTable.vue
+++ b/apps/vben5/packages/@abp/blob-management/src/components/containers/BlobContainerTable.vue
@@ -109,7 +109,8 @@ const gridOptions: VxeGridProps<BlobContainerDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/data-protection/src/components/entity-type-infos/EntityTypeInfoTable.vue
+++ b/apps/vben5/packages/@abp/data-protection/src/components/entity-type-infos/EntityTypeInfoTable.vue
@@ -91,7 +91,8 @@ const gridOptions: VxeGridProps<EntityTypeInfoDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/demo/src/components/books/BookTable.vue
+++ b/apps/vben5/packages/@abp/demo/src/components/books/BookTable.vue
@@ -108,7 +108,8 @@ const gridOptions: VxeGridProps<BookDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/gdpr/src/components/GdprTable.vue
+++ b/apps/vben5/packages/@abp/gdpr/src/components/GdprTable.vue
@@ -84,7 +84,8 @@ const gridOptions: VxeGridProps<GdprRequestDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/identity/src/components/claim-types/ClaimTypeTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/claim-types/ClaimTypeTable.vue
@@ -154,7 +154,8 @@ const gridOptions: VxeGridProps<IdentityClaimTypeDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/organization-units/OrganizationUnitRoleTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/organization-units/OrganizationUnitRoleTable.vue
@@ -84,7 +84,8 @@ const gridOptions: VxeGridProps<IdentityRoleDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/organization-units/OrganizationUnitUserTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/organization-units/OrganizationUnitUserTable.vue
@@ -90,7 +90,8 @@ const gridOptions: VxeGridProps<IdentityUserDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/organization-units/SelectMemberModal.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/organization-units/SelectMemberModal.vue
@@ -112,7 +112,8 @@ const gridOptions: VxeGridProps<IdentityUserDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/identity/src/components/organization-units/SelectRoleModal.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/organization-units/SelectRoleModal.vue
@@ -104,7 +104,8 @@ const gridOptions: VxeGridProps<IdentityRoleDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/identity/src/components/roles/RoleTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/roles/RoleTable.vue
@@ -120,7 +120,8 @@ const gridOptions: VxeGridProps<IdentityRoleDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/security-logs/SecurityLogTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/security-logs/SecurityLogTable.vue
@@ -185,7 +185,8 @@ const gridOptions: VxeGridProps<SecurityLogDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/sessions/SessionTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/sessions/SessionTable.vue
@@ -168,7 +168,8 @@ const gridOptions: VxeGridProps<IdentitySessionDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/identity/src/components/users/UserTable.vue
+++ b/apps/vben5/packages/@abp/identity/src/components/users/UserTable.vue
@@ -168,7 +168,8 @@ const gridOptions: VxeGridProps<IdentityUserDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/notifications/src/components/my-notifilers/MyNotificationTable.vue
+++ b/apps/vben5/packages/@abp/notifications/src/components/my-notifilers/MyNotificationTable.vue
@@ -175,7 +175,8 @@ const gridOptions: VxeGridProps<Notification> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/notifications/src/components/send-records/NotificationSendRecordTable.vue
+++ b/apps/vben5/packages/@abp/notifications/src/components/send-records/NotificationSendRecordTable.vue
@@ -234,7 +234,8 @@ const gridOptions: VxeGridProps<NotificationSendRecordDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/openiddict/src/components/applications/ApplicationTable.vue
+++ b/apps/vben5/packages/@abp/openiddict/src/components/applications/ApplicationTable.vue
@@ -146,7 +146,8 @@ const gridOptions: VxeGridProps<OpenIddictApplicationDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/openiddict/src/components/authorizations/AuthorizationTable.vue
+++ b/apps/vben5/packages/@abp/openiddict/src/components/authorizations/AuthorizationTable.vue
@@ -168,7 +168,8 @@ const gridOptions: VxeGridProps<OpenIddictAuthorizationDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/openiddict/src/components/scopes/ScopeTable.vue
+++ b/apps/vben5/packages/@abp/openiddict/src/components/scopes/ScopeTable.vue
@@ -121,7 +121,8 @@ const gridOptions: VxeGridProps<OpenIddictScopeDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/openiddict/src/components/tokens/TokenTable.vue
+++ b/apps/vben5/packages/@abp/openiddict/src/components/tokens/TokenTable.vue
@@ -195,7 +195,8 @@ const gridOptions: VxeGridProps<OpenIddictTokenDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/oss/src/components/containers/ContainerTable.vue
+++ b/apps/vben5/packages/@abp/oss/src/components/containers/ContainerTable.vue
@@ -120,7 +120,8 @@ const gridOptions: VxeGridProps<OssContainerDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/oss/src/components/objects/FileList.vue
+++ b/apps/vben5/packages/@abp/oss/src/components/objects/FileList.vue
@@ -150,7 +150,8 @@ const gridOptions: VxeGridProps<OssObjectDto> = {
   toolbarConfig: {
     custom: true,
     export: false,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/platform/src/components/layouts/LayoutTable.vue
+++ b/apps/vben5/packages/@abp/platform/src/components/layouts/LayoutTable.vue
@@ -144,7 +144,8 @@ const gridOptions: VxeGridProps<LayoutDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/platform/src/components/messages/email/EmailMessageTable.vue
+++ b/apps/vben5/packages/@abp/platform/src/components/messages/email/EmailMessageTable.vue
@@ -207,7 +207,8 @@ const gridOptions: VxeGridProps<EmailMessageDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/platform/src/components/messages/sms/SmsMessageTable.vue
+++ b/apps/vben5/packages/@abp/platform/src/components/messages/sms/SmsMessageTable.vue
@@ -188,7 +188,8 @@ const gridOptions: VxeGridProps<SmsMessageDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/saas/src/components/editions/EditionTable.vue
+++ b/apps/vben5/packages/@abp/saas/src/components/editions/EditionTable.vue
@@ -103,7 +103,8 @@ const gridOptions: VxeGridProps<EditionDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/saas/src/components/tenants/TenantTable.vue
+++ b/apps/vben5/packages/@abp/saas/src/components/tenants/TenantTable.vue
@@ -128,7 +128,8 @@ const gridOptions: VxeGridProps<TenantDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/tasks/src/components/job-infos/JobInfoTable.vue
+++ b/apps/vben5/packages/@abp/tasks/src/components/job-infos/JobInfoTable.vue
@@ -387,7 +387,8 @@ const gridOptions: VxeGridProps<BackgroundJobInfoDto> = {
     },
   },
   toolbarConfig: {
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
   },

--- a/apps/vben5/packages/@abp/webhooks/src/components/send-attempts/WebhookSendAttemptTable.vue
+++ b/apps/vben5/packages/@abp/webhooks/src/components/send-attempts/WebhookSendAttemptTable.vue
@@ -211,7 +211,8 @@ const gridOptions: VxeGridProps<WebhookSendRecordDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,

--- a/apps/vben5/packages/@abp/webhooks/src/components/subscriptions/WebhookSubscriptionTable.vue
+++ b/apps/vben5/packages/@abp/webhooks/src/components/subscriptions/WebhookSubscriptionTable.vue
@@ -210,7 +210,8 @@ const gridOptions: VxeGridProps<WebhookSubscriptionDto> = {
   toolbarConfig: {
     custom: true,
     export: true,
-    refresh: {
+    refresh: true,
+    refreshOptions: {
       code: 'query',
     },
     zoom: true,


### PR DESCRIPTION
Updates Vben5 ABP table toolbar configuration to use the current VXE API for refresh options.
VXE warns that object-valued `toolbar.refresh` is deprecated. The affected tables now use `refresh: true` with `refreshOptions`.

